### PR TITLE
Combine like notifications when possible

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -74,6 +74,12 @@ class Notification < ActiveRecord::Base
       n.save
     end
   end
+
+  private
+
+    def self.can_combine_likes?(last_notification, sit_link)
+      last_notification.present? and last_notification.link == sit_link and last_notification.message.include?('like')
+    end
 end
 
 # == Schema Information

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -55,14 +55,36 @@ class Notification < ActiveRecord::Base
 
   def self.send_new_sit_like_notification(user_id, like)
 
-    Notification.create(
-      message: "#{like.user.display_name} likes your entry.",
-      user_id: user_id,
-      link: Rails.application.routes.url_helpers.sit_path(like.likeable_id),
-      initiator: like.user.id,
-      object_type: 'like',
-      object_id: like.id
-    )
+    obj = Sit.find(like.likeable_id)
+    last_notification = User.find(user_id).notifications.first
+
+    # if last notification was a like of the same sit
+    if can_combine_likes?(last_notification, like)
+
+      like_count = Like.likers_for(obj).count
+      if like_count == 2
+        message = "#{like.user.display_name} and 1 other person liked your entry."
+      else
+        message = "#{like.user.display_name} and #{like_count - 1} other people liked your entry."
+      end
+      last_notification.update(
+        message: message,
+        initiator: like.user.id
+      )
+
+    else
+
+      Notification.create(
+        message: "#{like.user.display_name} likes your entry.",
+        user_id: user_id,
+        link: Rails.application.routes.url_helpers.sit_path(like.likeable_id),
+        initiator: like.user.id,
+        object_type: 'like',
+        object_id: like.id
+      )
+
+    end
+
 
   end
 
@@ -77,8 +99,8 @@ class Notification < ActiveRecord::Base
 
   private
 
-    def self.can_combine_likes?(last_notification, sit_link)
-      last_notification.present? and last_notification.link == sit_link and last_notification.message.include?('like')
+    def self.can_combine_likes?(last_notification, like)
+      last_notification.present? and last_notification.object_id == like.likeable_id and last_notification.object_type == 'like'
     end
 end
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -110,11 +110,18 @@ describe Notification do
   end
 
   describe 'Likes a sit' do
-    it 'notifies user that sit was liked' do
+    before do
       @buddha = create :user
       @ananda = create :user, username: 'ananda'
-      @sit = create :sit, user: @buddha
+      @genko = create :user, username: 'genko'
+      @jiho = create :user, username: 'jiho'
+      @daiko = create :user, username: 'daiko'
+      @eido = create :user, username: 'eido'
 
+      @sit = create :sit, user: @buddha
+    end
+
+    it 'notifies user that sit was liked' do
       @ananda.like!(@sit)
 
       expect(@buddha.notifications.unread.count).to eq 1
@@ -123,6 +130,29 @@ describe Notification do
       expect(@buddha.notifications.first.initiator).to eq @ananda.id
       expect(@buddha.notifications.first.object_type).to eq 'like'
       expect(@buddha.notifications.first.object_id).to eq @sit.likes.first.id
+    end
+
+    it 'combines 2 consecutive likes in to one notification' do
+      @ananda.like!(@sit)
+      @genko.like!(@sit)
+
+      expect(@buddha.notifications.unread.count).to eq 1
+      expect(@buddha.notifications.first.message).to eq 'genko and 1 other person liked your entry.'
+      expect(@buddha.notifications.first.link).to eq sit_path(@sit)
+      expect(@buddha.notifications.first.initiator).to eq @genko.id
+    end
+
+    it 'combines 5 consecutive likes in to one notification' do
+      @ananda.like!(@sit)
+      @genko.like!(@sit)
+      @jiho.like!(@sit)
+      @daiko.like!(@sit)
+      @eido.like!(@sit)
+
+      expect(@buddha.notifications.unread.count).to eq 1
+      expect(@buddha.notifications.first.message).to eq 'eido and 4 other people liked your entry.'
+      expect(@buddha.notifications.first.link).to eq sit_path(@sit)
+      expect(@buddha.notifications.first.initiator).to eq @eido.id
     end
   end
 


### PR DESCRIPTION
Combines the likes. Determining whether the notification was a like or not feels a little loose. It my be worth it to update the Notification model to store explicitly what type of notification it is. I will create an issue to discuss that.