### PR TITLE
Fix failing Travis like tests

### DIFF
--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -8,7 +8,7 @@ class Like < ActiveRecord::Base
   after_save :create_notification
 
   def self.likers_for(obj)
-    obj.likes.map { |u| User.find(u.user_id) }.reverse
+    obj.likes.order(id: :asc).map { |u| User.find(u.user_id) }
   end
 
   private


### PR DESCRIPTION
Looks like the Travis server is ordering the likes the opposite way our local machines are. So, maybe explicitly stating the order will help?