### PR TITLE
Fix previous month link

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,7 +43,7 @@ class UsersController < ApplicationController
     month = params[:month] ? params[:month] : Date.today.month
     year = params[:year] ? params[:year] : Date.today.year
 
-    index = @by_month[:list_of_months].index "#{year} #{month}" if @user.sits.present?
+    index = @by_month[:list_of_months].index "#{year} #{sprintf '%02d', month}" if @user.sits.present?
 
     # Generate prev/next links
     # .. for someone who's sat this month


### PR DESCRIPTION
The issue was the way it was indexing the User `journal_entries` method result. It returns months with leading zeroes, `2015 01`, and `Date.today.month` only returns the integer `1`.