### PR TITLE
Fix user details icon

### DIFF
--- a/app/views/users/_details.html.erb
+++ b/app/views/users/_details.html.erb
@@ -29,7 +29,7 @@
   <% if request.path != '/me' %>
     <% if !@user.style.blank? %>
       <div class="info-block">
-        <div class="icon"><i class="fa fa-navicon"></i></div>
+        <div class="icon"><i class="fa fa-bars"></i></div>
         <div class="value"> <%= @user.style %></div>
       </div>
     <% end %>


### PR DESCRIPTION
Looks like the site is currently using Font Awesome 4.0.3, which doesn't contain the `fa-navicon` alias. See [here](https://github.com/FortAwesome/Font-Awesome/blob/v4.0.3/css/font-awesome.css). But, it does contain `fa-bars` which is the icon it was referencing.