### PR TITLE
Properly display html entities in sit teasers

### DIFF
--- a/app/helpers/sits_helper.rb
+++ b/app/helpers/sits_helper.rb
@@ -4,12 +4,12 @@ module SitsHelper
 		if search
 			excerpt = excerpt(stripped, search, radius: 200)
 			if !excerpt.blank?
-				return highlight(excerpt, search)
+				return highlight(excerpt, search, :escape => false)
 			else
-				return truncate(stripped, :length => length, :omission => " ...")
+				return truncate(stripped, :length => length, :omission => " ...", :escape => false)
 			end
 		end
-		return truncate(stripped, :length => length, :omission => " ...")
+		return truncate(stripped, :length => length, :omission => " ...", :escape => false)
 	end
 
 	def teaser_title(sit, type = false)


### PR DESCRIPTION
I was able to fix it by setting escape to false for the truncate calls. I thought this might cause issues with sits that contain other html entities, like lists or bold or whatnot. But I tested several and there doesn't seem to be any issues. Is this going to cause issues somehwere?